### PR TITLE
refactor: fix critical code inconsistencies (types, protocols, logging)

### DIFF
--- a/.github/workflows/diff-context.yml
+++ b/.github/workflows/diff-context.yml
@@ -1,0 +1,10 @@
+name: Diff Context
+on: [pull_request]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  diff:
+    uses: nikolay-e/treemapper-action/.github/workflows/diff-context.yml@v1

--- a/src/arbitrium_core/application/execution/executor.py
+++ b/src/arbitrium_core/application/execution/executor.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from arbitrium_core.application.workflow.nodes.base import BaseNode
 from arbitrium_core.application.workflow.registry import registry
+from arbitrium_core.domain.errors import GraphValidationError
 from arbitrium_core.shared.logging import get_contextual_logger
 
 logger = get_contextual_logger(__name__)
@@ -158,7 +159,9 @@ class BaseExecutor(ABC):
                 errors.append(f"Unknown node type: {node_type}")
 
         if errors:
-            raise ValueError(f"Graph build errors: {'; '.join(errors)}")
+            raise GraphValidationError(
+                f"Graph build errors: {'; '.join(errors)}"
+            )
 
         dependencies: dict[str, list[str]] = defaultdict(list)
         connections: dict[str, list[tuple[str, str, str]]] = defaultdict(list)
@@ -178,11 +181,11 @@ class BaseExecutor(ABC):
             )
 
             if source not in node_instances:
-                raise ValueError(
+                raise GraphValidationError(
                     f"Edge references unknown source node: {source}"
                 )
             if target not in node_instances:
-                raise ValueError(
+                raise GraphValidationError(
                     f"Edge references unknown target node: {target}"
                 )
 
@@ -226,7 +229,9 @@ class BaseExecutor(ABC):
                         queue.append(other_id)
 
         if len(result) != len(nodes):
-            raise ValueError("Graph contains a cycle - check node connections")
+            raise GraphValidationError(
+                "Graph contains a cycle - check node connections"
+            )
 
         return result
 
@@ -260,7 +265,7 @@ class BaseExecutor(ABC):
             ]
 
             if not current_layer:
-                raise ValueError(
+                raise GraphValidationError(
                     "Graph contains a cycle - check node connections"
                 )
 
@@ -358,7 +363,7 @@ class BaseExecutor(ABC):
         node_instances: dict[str, BaseNode],
     ) -> None:
         if not node_instances:
-            raise ValueError("No valid nodes in graph")
+            raise GraphValidationError("No valid nodes in graph")
 
     def _build_execution_graph(
         self,

--- a/src/arbitrium_core/domain/errors.py
+++ b/src/arbitrium_core/domain/errors.py
@@ -16,6 +16,7 @@ __all__ = [
     "ExceptionClassifier",
     "FatalError",
     "FileSystemError",
+    "GraphValidationError",
     "InputError",
     "ModelError",
     "ModelResponseError",
@@ -109,6 +110,23 @@ class TournamentTimeoutError(ArbitriumError):
         self.elapsed = elapsed
         self.timeout = timeout
         enhanced_message = f"Tournament timeout: {elapsed:.1f}s >= limit {timeout:.1f}s. {message}"
+        super().__init__(enhanced_message, *args)
+
+
+class GraphValidationError(ArbitriumError):
+    """Exception for workflow graph validation errors."""
+
+    def __init__(
+        self,
+        message: str,
+        node_id: str | None = None,
+        *args: object,
+        **kwargs: object,
+    ) -> None:
+        self.node_id = node_id
+        enhanced_message = message
+        if node_id:
+            enhanced_message = f"[Node: {node_id}] {enhanced_message}"
         super().__init__(enhanced_message, *args)
 
 

--- a/src/arbitrium_core/domain/knowledge/bank.py
+++ b/src/arbitrium_core/domain/knowledge/bank.py
@@ -63,14 +63,16 @@ class EnhancedKnowledgeBank:
                     else None
                 )
                 self.logger.warning(
-                    f"Leader not determined yet, using fallback model: {extractor_model_key}"
+                    "Leader not determined yet, using fallback model: %s",
+                    extractor_model_key,
                 )
             else:
                 leader_display = self.comparison.anon_mapping.get(
                     extractor_model_key, extractor_model_key
                 )
                 self.logger.info(
-                    f"Using tournament leader {leader_display} for insight extraction"
+                    "Using tournament leader %s for insight extraction",
+                    leader_display,
                 )
             return extractor_model_key
         else:
@@ -129,13 +131,16 @@ class EnhancedKnowledgeBank:
         self, response_content: str, extractor_model_key: str
     ) -> list[str]:
         self.logger.debug(
-            f"[{extractor_model_key}] Raw insight extraction response: {response_content}"
+            "[%s] Raw insight extraction response: %s",
+            extractor_model_key,
+            response_content,
         )
 
         if detect_apology_or_refusal(response_content):
             self.logger.error(
-                f"[{extractor_model_key}] Model returned apology/refusal instead of insight extraction. "
-                f"Response: {response_content}"
+                "[%s] Model returned apology/refusal instead of insight extraction. Response: %s",
+                extractor_model_key,
+                response_content,
             )
             return []
 
@@ -145,7 +150,9 @@ class EnhancedKnowledgeBank:
 
         if not claims:
             self.logger.warning(
-                f"[{extractor_model_key}] No valid insights found in response. Response: {response_content}"
+                "[%s] No valid insights found in response. Response: %s",
+                extractor_model_key,
+                response_content,
             )
 
         return claims

--- a/src/arbitrium_core/engine.py
+++ b/src/arbitrium_core/engine.py
@@ -9,7 +9,7 @@ from arbitrium_core.ports.llm import BaseModel, ModelResponse
 from arbitrium_core.ports.similarity import SimilarityEngine
 from arbitrium_core.shared.logging import get_contextual_logger
 
-logger = get_contextual_logger("arbitrium")
+logger = get_contextual_logger(__name__)
 
 
 class _InternalEventHandler:
@@ -157,7 +157,7 @@ class Arbitrium:
                 f"Failed models: {list(self._failed_models.keys())}"
             )
 
-        logger.info(f"Starting tournament with {len(models)} models")
+        logger.info("Starting tournament with %d models", len(models))
 
         comparison = self._create_comparison(models)
         self._last_comparison = comparison
@@ -198,7 +198,7 @@ class Arbitrium:
             raise RuntimeError("No healthy models available")
 
         logger.info(
-            f"Running prompt through {len(self._healthy_models)} models"
+            "Running prompt through %d models", len(self._healthy_models)
         )
 
         results = {}
@@ -206,8 +206,8 @@ class Arbitrium:
             try:
                 response = await self.run_single_model(model_key, prompt)
                 results[model_key] = response
-            except Exception as e:
-                logger.error(f"Failed to run {model_key}: {e}")
+            except Exception:
+                logger.exception("Failed to run %s", model_key)
                 # Continue with other models
                 continue
 

--- a/src/arbitrium_core/ports/cache.py
+++ b/src/arbitrium_core/ports/cache.py
@@ -1,14 +1,11 @@
-from abc import ABC, abstractmethod
+from typing import Protocol
 
 
-class CacheProtocol(ABC):
-    @abstractmethod
+class CacheProtocol(Protocol):
     def get(
         self, model_name: str, prompt: str, temperature: float, max_tokens: int
-    ) -> tuple[str, float] | None:
-        pass
+    ) -> tuple[str, float] | None: ...
 
-    @abstractmethod
     def set(
         self,
         model_name: str,
@@ -17,13 +14,8 @@ class CacheProtocol(ABC):
         max_tokens: int,
         response: str,
         cost: float,
-    ) -> None:
-        pass
+    ) -> None: ...
 
-    @abstractmethod
-    def clear(self) -> None:
-        pass
+    def clear(self) -> None: ...
 
-    @abstractmethod
-    def close(self) -> None:
-        pass
+    def close(self) -> None: ...

--- a/src/arbitrium_core/ports/llm.py
+++ b/src/arbitrium_core/ports/llm.py
@@ -1,6 +1,9 @@
 from abc import ABC, abstractmethod
 from collections.abc import Awaitable
-from typing import Any, Protocol
+from typing import TYPE_CHECKING, Any, Protocol
+
+if TYPE_CHECKING:
+    from arbitrium_core.ports.cache import CacheProtocol
 
 
 class ModelResponse:
@@ -94,5 +97,5 @@ class ModelProvider(Protocol):
         cls,
         model_key: str,
         config: dict[str, Any],
-        response_cache: Any | None = None,
+        response_cache: "CacheProtocol | None" = None,
     ) -> Awaitable[BaseModel]: ...

--- a/src/arbitrium_core/ports/secrets.py
+++ b/src/arbitrium_core/ports/secrets.py
@@ -1,14 +1,9 @@
-from abc import ABC, abstractmethod
-from typing import Any
+from typing import Any, Protocol
 
 
-class SecretsProvider(ABC):
-    @abstractmethod
-    def get_secret(self, key: str) -> str | None:
-        pass
+class SecretsProvider(Protocol):
+    def get_secret(self, key: str) -> str | None: ...
 
-    @abstractmethod
     def load_secrets(
         self, config: dict[str, Any], required_providers: list[str]
-    ) -> None:
-        pass
+    ) -> None: ...

--- a/src/arbitrium_core/ports/similarity.py
+++ b/src/arbitrium_core/ports/similarity.py
@@ -1,22 +1,13 @@
-from abc import ABC, abstractmethod
-from typing import Any
+from typing import Any, Protocol
 
 
-class SimilarityEngine(ABC):
-    @abstractmethod
-    def fit(self, texts: list[str]) -> None:
-        pass
+class SimilarityEngine(Protocol):
+    def fit(self, texts: list[str]) -> None: ...
 
-    @abstractmethod
-    def transform(self, texts: list[str]) -> Any:
-        pass
+    def transform(self, texts: list[str]) -> Any: ...
 
-    @abstractmethod
-    def is_fitted(self) -> bool:
-        pass
+    def is_fitted(self) -> bool: ...
 
-    @abstractmethod
     def compute_similarity(
         self, query_vector: Any, corpus_vectors: Any
-    ) -> list[float]:
-        pass
+    ) -> list[float]: ...


### PR DESCRIPTION
- Replace ABC with Protocol for structural typing (cache, similarity, secrets)
- Add GraphValidationError for workflow validation errors
- Fix Any types to specific types (logger, base_dir, response_cache)
- Convert f-strings to %-formatting in logging for deferred evaluation
- Replace logger.error with logger.exception in except blocks
- Convert relative imports to absolute in tournament.py
- Standardize logger naming to __name__