### PR TITLE
fix(cost): account for interrogation rounds in the estimate

### DIFF
--- a/src/certamen/application/cost/estimator.py
+++ b/src/certamen/application/cost/estimator.py
@@ -195,7 +195,13 @@ def estimate_cost(
     eliminate_count = (
         int(_node_prop(elim_nodes[0], "count", 1)) if elim_nodes else 1
     )
-    has_interrogation = bool(_find_nodes(workflow, "tournament/interrogate"))
+    interrogate_nodes = _find_nodes(workflow, "tournament/interrogate")
+    has_interrogation = bool(interrogate_nodes)
+    interrogate_rounds = (
+        max(1, int(_node_prop(interrogate_nodes[0], "rounds", 1)))
+        if interrogate_nodes
+        else 1
+    )
     has_peer_review = bool(_find_nodes(workflow, "tournament/peer_review"))
     n_diverge_improve = len(_find_nodes(workflow, "tournament/improve"))
 
@@ -209,12 +215,14 @@ def estimate_cost(
     # Per-model call counts (attribution). Survivor-round calls (peer_review,
     # converge) have unknown identity → attributed evenly across competitors.
     pairs_examiner_per_iter = n - 1  # each model examines n-1 others per iter
+    # Interrogation loops up to `rounds` follow-up passes per pair per iteration.
+    interro_per_iter = pairs_examiner_per_iter * interrogate_rounds
     per_model = {
         "generate": div_iters,
-        "interrogate_questions": div_iters * pairs_examiner_per_iter
+        "interrogate_questions": div_iters * interro_per_iter
         if has_interrogation
         else 0,
-        "interrogate_answers": div_iters * pairs_examiner_per_iter
+        "interrogate_answers": div_iters * interro_per_iter
         if has_interrogation
         else 0,
         # diamond has both a divergence-improve and a convergence-improve node;
@@ -228,11 +236,7 @@ def estimate_cost(
     stalled_total = round(
         (
             stalled_div
-            + (
-                2 * stalled_div * pairs_examiner_per_iter
-                if has_interrogation
-                else 0
-            )
+            + (2 * stalled_div * interro_per_iter if has_interrogation else 0)
             + (stalled_div if n_diverge_improve >= 1 else 0)
             + (stalled_pr / n if has_peer_review else 0)
             + (stalled_ci / n if n_diverge_improve >= 2 else 0)
@@ -271,9 +275,15 @@ def estimate_cost(
     stalled_scale = (stalled_total / total_calls) if total_calls else 1.0
     stalled_expected = total_expected * stalled_scale
 
+    interro_note = (
+        f" Interrogation runs up to {interrogate_rounds} follow-up round(s) per "
+        f"pair (an upper bound — a round stops early if a model asks nothing)."
+        if has_interrogation and interrogate_rounds > 1
+        else ""
+    )
     assumptions = [
         f"{n} competitors; workflow re-runs the divergence phase every iteration "
-        f"(no memoization) → {div_iters} divergence iterations.",
+        f"(no memoization) → {div_iters} divergence iterations.{interro_note}",
         f"Call count: {total_calls} (healthy) … up to {stalled_total} "
         f"(if peer-review scores fail to parse → no elimination → runs to "
         f"max_rounds={max_rounds}).",

--- a/tests/integration/test_e2e_cost_estimate.py
+++ b/tests/integration/test_e2e_cost_estimate.py
@@ -46,16 +46,33 @@ def _flagship_diamond_config() -> SlimConfig:
 
 class TestCallModel:
     def test_diamond_four_models_matches_empirical_call_count(self) -> None:
+        # The empirical ~143-144 calls / 4 iterations was measured with a single
+        # interrogation round; pin rounds=1 to keep that anchor honest (the
+        # shipped default is now rounds=3, exercised in the scaling test below).
         slim = _ollama_diamond_config()
+        slim.overrides["interrogate.rounds"] = 1
         workflow = materialize_workflow(slim)
         est = estimate_cost(workflow, slim.price_overrides)
-        # Healthy 4-model diamond re-runs divergence every iteration; measured
-        # real runs logged ~143-144 calls over 4 iterations.
         assert est.n_competitors == 4
         assert est.divergence_iterations == 4
         assert est.total_calls == 143
         # Stalled (scores never parse) runs to max_rounds > healthy.
         assert est.stalled_total_calls > est.total_calls
+
+    def test_interrogation_rounds_scale_call_count(self) -> None:
+        base = _ollama_diamond_config()
+        base.overrides["interrogate.rounds"] = 1
+        one = estimate_cost(materialize_workflow(base), base.price_overrides)
+
+        three = _ollama_diamond_config()
+        three.overrides["interrogate.rounds"] = 3
+        est3 = estimate_cost(
+            materialize_workflow(three), three.price_overrides
+        )
+
+        # More interrogation rounds ⇒ strictly more calls (interrogation is the
+        # dominant call class), but generate/improve/peer-review are unchanged.
+        assert est3.total_calls > one.total_calls
 
     def test_band_is_ordered(self) -> None:
         slim = _flagship_diamond_config()


### PR DESCRIPTION
The estimator counted a single interrogation round, but interrogation now loops up to N follow-up rounds (diamond default 3) — the dominant call class was undercounted. Reads `interrogate.rounds` and scales interrogation calls; for `config.diffctx-theory.yml` this lifts the estimate from ~$28 to **~$64 expected** (335 calls). Adds a rounds-scaling test; pins the empirical-143 anchor test to rounds=1.

https://claude.ai/code/session_016TPPoxfptsEXJFdAiz9mP7